### PR TITLE
fixed warnings in gemspec

### DIFF
--- a/ruby-filemagic.gemspec
+++ b/ruby-filemagic.gemspec
@@ -10,11 +10,11 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.authors = ["Travis Whitton", "Jens Wille"]
   s.date = "2015-02-06"
-  s.description = "Ruby bindings to the magic(4) library"
+  s.description = "Ruby gem that provides standardized interface to the filemagic library."
   s.email = "jens.wille@gmail.com"
   s.extensions = ["ext/filemagic/extconf.rb"]
   s.extra_rdoc_files = ["README", "ChangeLog", "ext/filemagic/filemagic.c"]
-  s.files = ["ChangeLog", "README", "Rakefile", "TODO", "ext/filemagic/extconf.rb", "ext/filemagic/filemagic.c", "ext/filemagic/filemagic.h", "lib/filemagic.rb", "lib/filemagic/ext.rb", "lib/filemagic/magic.mgc", "lib/filemagic/version.rb", "lib/ruby-filemagic.rb", "test/excel-example.xls", "test/filemagic_test.rb", "test/leaktest.rb", "test/mahoro.c", "test/perl", "test/perl.mgc", "test/pyfile", "test/pyfile-compressed.gz", "test/pylink"]
+  s.files = ["ChangeLog", "README", "Rakefile", "TODO", "ext/filemagic/extconf.rb", "ext/filemagic/filemagic.c", "ext/filemagic/filemagic.h", "lib/filemagic.rb", "lib/filemagic/ext.rb", "lib/filemagic/version.rb", "lib/ruby-filemagic.rb", "test/excel-example.xls", "test/filemagic_test.rb", "test/leaktest.rb", "test/mahoro.c", "test/perl", "test/perl.mgc", "test/pyfile", "test/pyfile-compressed.gz", "test/pylink"]
   s.homepage = "http://github.com/blackwinter/ruby-filemagic"
   s.licenses = ["Ruby"]
   s.post_install_message = "\nruby-filemagic-0.6.2 [2015-02-06]:\n\n* Improved Windows support (issue #10 by Matt Hoyle).\n* Fixed FileMagic.path to account for missing magic file.\n\n"
@@ -28,19 +28,19 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<hen>, [">= 0.8.1", "~> 0.8"])
-      s.add_development_dependency(%q<rake>, [">= 0"])
-      s.add_development_dependency(%q<rake-compiler>, [">= 0"])
-      s.add_development_dependency(%q<test-unit>, [">= 0"])
+      s.add_development_dependency(%q<rake>, ["~> 0"])
+      s.add_development_dependency(%q<rake-compiler>, ["~> 0"])
+      s.add_development_dependency(%q<test-unit>, ["~> 0"])
     else
       s.add_dependency(%q<hen>, [">= 0.8.1", "~> 0.8"])
-      s.add_dependency(%q<rake>, [">= 0"])
-      s.add_dependency(%q<rake-compiler>, [">= 0"])
-      s.add_dependency(%q<test-unit>, [">= 0"])
+      s.add_dependency(%q<rake>, ["~> 0"])
+      s.add_dependency(%q<rake-compiler>, ["~> 0"])
+      s.add_dependency(%q<test-unit>, ["~> 0"])
     end
   else
     s.add_dependency(%q<hen>, [">= 0.8.1", "~> 0.8"])
-    s.add_dependency(%q<rake>, [">= 0"])
-    s.add_dependency(%q<rake-compiler>, [">= 0"])
-    s.add_dependency(%q<test-unit>, [">= 0"])
+    s.add_dependency(%q<rake>, ["~> 0"])
+    s.add_dependency(%q<rake-compiler>, ["~> 0"])
+    s.add_dependency(%q<test-unit>, ["~> 0"])
   end
 end


### PR DESCRIPTION
This resolves the following warnings when performing a gem build:

WARNING:  description and summary are identical
WARNING:  open-ended dependency on rake (>= 0, development) is not recommended
  if rake is semantically versioned, use:
    add_development_dependency 'rake', '~> 0'
WARNING:  open-ended dependency on rake-compiler (>= 0, development) is not recommended
  if rake-compiler is semantically versioned, use:
    add_development_dependency 'rake-compiler', '~> 0'
WARNING:  open-ended dependency on test-unit (>= 0, development) is not recommended
  if test-unit is semantically versioned, use:
    add_development_dependency 'test-unit', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
