### PR TITLE
Fix no function exception if no 'magic_getpath' function

### DIFF
--- a/ext/filemagic/filemagic.c
+++ b/ext/filemagic/filemagic.c
@@ -11,10 +11,8 @@ rb_magic_getpath(VALUE klass) {
   if (magic_getpath) {
     path = magic_getpath(NULL, 0);
   } else {
-    cStderr = rb_gv_get("stderr");
-    argv[0] = rb_str_new_cstr("WARN: The function 'magic_getpath' isn't " \
-        "defined in 'libmagic'. The return valus is defaulting to nil");
-    rb_io_puts(sizeof(argv)/sizeof(VALUE), argv, cStderr);
+    rb_raise(rb_eNoMethodError,
+        "The function 'magic_getpath' isn't defined");
   }
   return path != NULL ? rb_str_new2(path) : Qnil;
 }

--- a/ext/filemagic/filemagic.c
+++ b/ext/filemagic/filemagic.c
@@ -1,9 +1,21 @@
 #include "filemagic.h"
 
+const char *magic_getpath(const char *, int) __attribute__((weak));
+
 /* Returns the magic path */
 static VALUE
 rb_magic_getpath(VALUE klass) {
-  const char *path = magic_getpath(NULL, 0);
+  const char *path = NULL;
+  VALUE cStderr, argv[1];
+
+  if (magic_getpath) {
+    path = magic_getpath(NULL, 0);
+  } else {
+    cStderr = rb_gv_get("stderr");
+    argv[0] = rb_str_new_cstr("WARN: The function 'magic_getpath' isn't " \
+        "defined in 'libmagic'. The return valus is defaulting to nil");
+    rb_io_puts(sizeof(argv)/sizeof(VALUE), argv, cStderr);
+  }
   return path != NULL ? rb_str_new2(path) : Qnil;
 }
 

--- a/ext/filemagic/filemagic.c
+++ b/ext/filemagic/filemagic.c
@@ -6,7 +6,6 @@ const char *magic_getpath(const char *, int) __attribute__((weak));
 static VALUE
 rb_magic_getpath(VALUE klass) {
   const char *path = NULL;
-  VALUE cStderr, argv[1];
 
   if (magic_getpath) {
     path = magic_getpath(NULL, 0);
@@ -276,6 +275,15 @@ Init_ruby_filemagic() {
 #endif
 #ifdef MAGIC_APPLE
   rb_define_const(cFileMagic, "MAGIC_APPLE",             INT2FIX(MAGIC_APPLE));
+#endif
+#ifdef MAGIC_EXTENSION
+  rb_define_const(cFileMagic, "MAGIC_EXTENSION",         INT2FIX(MAGIC_EXTENSION));
+#endif
+#ifdef MAGIC_COMPRESS_TRANSP
+  rb_define_const(cFileMagic, "MAGIC_COMPRESS_TRANSP",   INT2FIX(MAGIC_COMPRESS_TRANSP));
+#endif
+#ifdef MAGIC_NODESC
+  rb_define_const(cFileMagic, "MAGIC_NODESC",            INT2FIX(MAGIC_NODESC));
 #endif
 #ifdef MAGIC_NO_CHECK_COMPRESS
   rb_define_const(cFileMagic, "MAGIC_NO_CHECK_COMPRESS", INT2FIX(MAGIC_NO_CHECK_COMPRESS));

--- a/lib/filemagic.rb
+++ b/lib/filemagic.rb
@@ -11,7 +11,7 @@ class FileMagic
 
   DEFAULT_MAGIC = __FILE__.sub(/\.rb\z/, '/magic.mgc')
 
-  ENV['MAGIC'] ||= DEFAULT_MAGIC unless path
+  ENV['MAGIC'] ||= DEFAULT_MAGIC unless path rescue NoMethodError
 
   # Map flag names to their values (:name => Integer).
   FLAGS_BY_SYM = [


### PR DESCRIPTION
In version of the libmagic1.0.0 the 'magic_getpath' function is absent. So the code `require 'filemagic'` throws the exception of no function. The patch just fixes the problem defaulting the call to `FileMagic.path`
to `nil`.