### PR TITLE
List default lib and header directories.

### DIFF
--- a/ext/filemagic/extconf.rb
+++ b/ext/filemagic/extconf.rb
@@ -1,10 +1,22 @@
 require 'mkmf'
 
+HEADER_DIRS = [
+  '/opt/local/include', # MacPorts
+  '/usr/local/include', # compiled from source and Homebrew
+  '/usr/include',       # system
+]
+
+LIB_DIRS = [
+  '/opt/local/lib', # MacPorts
+  '/usr/local/lib', # compiled from source and Homebrew
+  '/usr/lib',       # system
+]
+
 $CFLAGS << ' -Wall' if ENV['WALL']
 $LDFLAGS << ' -static-libgcc' if RUBY_PLATFORM =~ /cygwin|mingw|mswin/
 
-dir_config('magic')
-dir_config('gnurx')
+dir_config('magic', HEADER_DIRS, LIB_DIRS)
+dir_config('gnurx', HEADER_DIRS, LIB_DIRS)
 
 have_library('gnurx')
 


### PR DESCRIPTION
Should allow installing on OS X without specifying `--with-magic-lib=` and `--with-magic-include=`.

I have two Macs. On one of them the extension installs fine without the need to supply any config arguments. On the other I have to tell it about `/usr/local`. Both have same ruby version, both have the same Homebrew packages installed, libmagic is installed on both of them. The only difference I can tell is that one has Developer Command Line Tools (extension installs fine) and the other has Xcode instead (extension install fails).

With this change the `mkmf` succeeds on both computers. Not sure if there are any negative side effects.