### PR TITLE
Don't use default include and library directories with dir_config

### DIFF
--- a/ext/filemagic/extconf.rb
+++ b/ext/filemagic/extconf.rb
@@ -1,24 +1,10 @@
 require 'mkmf'
 
-HEADER_DIRS = [
-  '/opt/local/include', # MacPorts
-  '/usr/local/include', # compiled from source and Homebrew
-  '/opt/homebrew/include', # compiled from source and Homebrew (ARM based Macs)
-  '/usr/include',       # system
-]
-
-LIB_DIRS = [
-  '/opt/local/lib', # MacPorts
-  '/usr/local/lib', # compiled from source and Homebrew
-  '/opt/homebrew/lib', # compiled from source and Homebrew (ARM based Macs)
-  '/usr/lib',       # system
-]
-
 $CFLAGS << ' -Wall' if ENV['WALL']
 $LDFLAGS << ' -static-libgcc' if RUBY_PLATFORM =~ /cygwin|mingw|mswin/
 
-dir_config('magic', HEADER_DIRS, LIB_DIRS)
-dir_config('gnurx', HEADER_DIRS, LIB_DIRS)
+dir_config('magic')
+dir_config('gnurx')
 
 have_library('gnurx')
 


### PR DESCRIPTION
Using default directories in publicly available gems can cause problems because the directories are used when building unless all of them are overridden. For this gem it means running "gem install" with "--with-magic-dir=..." and "--with-gnurx-dir=..." (yes, even if gnurx isn't installed on the system). Kind of annoying to have to look at a gem's extconf.rb to see what dir_config calls are being made and what needs to be overridden because of defaults that conflict with how ruby was configured/installed.

The above discovery was prompted by having libmagic installed in both the system default location and a non-standard location (that ruby uses for a bunch of other third-party libraries). The following warning was issued when trying to use the gem unless the gem was installed with both '--with-magic-dir=..." and "-with-gnurx-dir=...":

  FileMagic v0.7.3: compiled magic version [5.40] does not match with
  shared library magic version [5.43]