### PR TITLE
Fixed "note:" output when compiling filemagic.c

### DIFF
--- a/ext/filemagic/filemagic.c
+++ b/ext/filemagic/filemagic.c
@@ -3,7 +3,7 @@
 /* Returns the magic version */
 static VALUE
 rb_magic_version(VALUE klass) {
-  char version[8] = "0";
+  char version[16] = "0";
 #ifdef HAVE_MAGIC_VERSION
   RB_MAGIC_SET_VERSION(magic_version() / 100, magic_version() % 100)
 #endif
@@ -208,7 +208,7 @@ RB_MAGIC_APPRENTICE(compile)
 
 void
 Init_ruby_filemagic() {
-  char version[8] = "0";
+  char version[16] = "0";
   cFileMagic = rb_define_class("FileMagic", rb_cObject);
 
 #if defined(FILE_VERSION_MAJOR)


### PR DESCRIPTION
Increased version string temporary buffers from 8 to 16 bytes to suppress the following note, and 17 or 18 other lines of output, when compiling filemagic.c:

  note: ‘sprintf’ output between 5 and 14 bytes into a destination
    of size 8