### PR TITLE
Default to using test-unit gem even if minitest_tu_shim is installed

### DIFF
--- a/test/filemagic_test.rb
+++ b/test/filemagic_test.rb
@@ -1,3 +1,5 @@
+gem 'test-unit' unless ENV.fetch("USE_TEST_UNIT", '').downcase == 'no'
+
 require 'test/unit'
 require 'filemagic'
 


### PR DESCRIPTION
Force test-unit gem to be used unless "USE_TEST_UNIT=no" is set in the environment. If "USE_TEST_UNIT=no" is set in the environment and minitest_tu_shim is installed, then minitest will be used instead of test-unit. If minitest_tu_shim isn't installed, then the environment variable doesn't matter and test-unit will be used.