### PR TITLE
Undefine allocation function for C extension class

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@
 
 = Revision history for ruby-filemagic
 
+== Unreleased []
+
+* Remove Warning 'warning: undefining the allocator of T_DATA class FileMagic'
+
 == 0.7.3 [2022-01-07]
 
 * Dockerfile to build native extension (pull request #26 by Pavel Lobashov).

--- a/ext/filemagic/filemagic.c
+++ b/ext/filemagic/filemagic.c
@@ -210,6 +210,7 @@ void
 Init_ruby_filemagic() {
   char version[8] = "0";
   cFileMagic = rb_define_class("FileMagic", rb_cObject);
+  rb_undef_alloc_func(cFileMagic);
 
 #if defined(FILE_VERSION_MAJOR)
   RB_MAGIC_SET_VERSION(FILE_VERSION_MAJOR, patchlevel)


### PR DESCRIPTION
* Undefine allocation function for C extension class

Since Ruby 3.2 a new warning is printed when a Ruby class created in a C extension does not specify an allocate function or undefine it.

```
warning: undefining the allocator of T_DATA class FileMagic (WarningHandlers::Ruby::Warning)
```

From my understanding, we only need to define an allocate function if the class uses a C struct and stores any values on it. Our classes don't do that in C, that's done in our Rust extension.

Closes #909

## Resources

https://bugs.ruby-lang.org/issues/18007
https://github.com/ruby/ruby/blob/6963f8f743b42f9004a0879cd66c550f18987352/doc/extension.rdoc#label-Write+the+C+Code https://ruby-doc.org/core-3.1.1/doc/extension_rdoc.html#label-C+struct+to+Ruby+object

https://github.com/rails-sqlserver/tiny_tds/issues/515 https://groups.google.com/g/sequel-talk/c/K0J80s4wGJU/m/BT-6FFhrAgAJ

## Other MR doing similar change
https://github.com/vmg/redcarpet/pull/721
https://github.com/appsignal/appsignal-ruby/pull/917